### PR TITLE
feat: 학생 클래스에서 졸업 요건 충족한 경우에도 출력하도록 수정

### DIFF
--- a/graduate/src/graduate/Student.java
+++ b/graduate/src/graduate/Student.java
@@ -79,51 +79,75 @@ public class Student {
                 graduationRule.getDoubleMajor() : graduationRule.getSingleMajor();
 
         if (totalCredit < graduationRule.getTotalCredit()) {
-            messages.add(String.format("총이수학점 부족 (%d/%d학점)",
+            messages.add(String.format("❌ 총이수학점 부족 (%d/%d학점)",
                     totalCredit, graduationRule.getTotalCredit()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 총이수학점 충족 (%d/%d학점)",
+                    totalCredit, graduationRule.getTotalCredit()));
         }
 
         if (majorCredit < requiredMajor) {
-            messages.add(String.format("전공학점 부족 (%d/%d학점)",
+            messages.add(String.format("❌ 전공학점 부족 (%d/%d학점)",
                     majorCredit, requiredMajor));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 전공학점 충족 (%d/%d학점)",
+                    majorCredit, requiredMajor));
         }
 
         if (generalCredit < graduationRule.getGeneralCredit()) {
-            messages.add(String.format("교양학점 부족 (%d/%d학점)",
+            messages.add(String.format("❌ 교양학점 부족 (%d/%d학점)",
                     generalCredit, graduationRule.getGeneralCredit()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 교양학점 충족 (%d/%d학점)",
+                    generalCredit, graduationRule.getGeneralCredit()));
         }
 
         if (mscCredit < graduationRule.getMscCredit()) {
-            messages.add(String.format("MSC학점 부족 (%d/%d학점)",
+            messages.add(String.format("❌ MSC학점 부족 (%d/%d학점)",
                     mscCredit, graduationRule.getMscCredit()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ MSC학점 충족 (%d/%d학점)",
+                    mscCredit, graduationRule.getMscCredit()));
         }
 
         if (majorRequired < graduationRule.getMajorRequired()) {
-            messages.add(String.format("전공필수 과목 이수 부족 (%d/%d과목)",
+            messages.add(String.format("❌ 전공필수 과목 이수 부족 (%d/%d과목)",
                     majorRequired, graduationRule.getMajorRequired()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 전공필수 과목 이수 충족 (%d/%d과목)",
+                    majorRequired, graduationRule.getMajorRequired()));
         }
 
         if (majorElective < graduationRule.getMajorElective()) {
-            messages.add(String.format("전공선택 과목 이수 부족 (%d/%d과목)",
+            messages.add(String.format("❌ 전공선택 과목 이수 부족 (%d/%d과목)",
                     majorElective, graduationRule.getMajorElective()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 전공선택 과목 이수 충족 (%d/%d과목)",
+                    majorElective, graduationRule.getMajorElective()));
         }
 
         if (facultyRequired < graduationRule.getFacultyRequired()) {
-            messages.add(String.format("학부기초필수 과목 이수 부족 (%d/%d과목)",
+            messages.add(String.format("❌ 학부기초필수 과목 이수 부족 (%d/%d과목)",
                     facultyRequired, graduationRule.getFacultyRequired()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 학부기초필수 과목 이수 충족 (%d/%d과목)",
+                    facultyRequired, graduationRule.getFacultyRequired()));
         }
 
         if (facultyElective < graduationRule.getFacultyElective()) {
-            messages.add(String.format("학부기초선택 과목 이수 부족 (%d/%d과목)",
+            messages.add(String.format("❌ 학부기초선택 과목 이수 부족 (%d/%d과목)",
                     facultyElective, graduationRule.getFacultyElective()));
             pass = false;
+        } else {
+            messages.add(String.format("✔ 학부기초선택 과목 이수 충족 (%d/%d과목)",
+                    facultyElective, graduationRule.getFacultyElective()));
         }
 
         if (pass)


### PR DESCRIPTION
## 요약

- Student.java의 checkGraduation() 메소드 로직을 수정했습니다. 교수님의 피드백을 반영하여, 이전에는 졸업 요건을 충족하지 못한 경우에만 메시지를 출력했지만, 이제는 졸업 요건을 충족한 경우에도 메시지로 출력하도록 수정했습니다.

## 관련 이슈

N/A

## 변경 유형

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

1. Student.java 파일의 checkGraduation() 메서드 로직이 변경되었습니다.
2. 총 학점, 전공 학점, 교양 학점, MSC 학점, 각 유형 별 이수 과목 수 등 총 8가지 졸업 요건에 대해, 요건을 충족하는 경우에도 (else 구문 추가) ✔ (항목) 충족 메시지를 출력하도록 확장했습니다.
3. 메시지 출력 시 ❌(부족) 또는 ✔(충족) 아이콘을 사용하여 상태를 시각적으로 구분했습니다

## 테스트

- [ ] 유닛/통합 테스트 추가 또는 갱신
- [x] 로컬에서 수동 테스트(브라우저/모바일)
- [ ] 엣지 케이스 확인(빈 값/긴 텍스트/이모지 등)

## 체크리스트

- [ ] 접근성 고려(키보드/스크린리더)
- [ ] i18n/문구 검토(한국어 자연스러움)
- [ ] 안전/모더레이션 정책 영향 검토(해당 시)
- [ ] 변경 로그/문서 업데이트
