### PR TITLE
전공학점 구할 때 '컴터'과목도 반영되게 수정

### DIFF
--- a/graduate/src/graduate/Student.java
+++ b/graduate/src/graduate/Student.java
@@ -80,6 +80,7 @@ public class Student {
                 case MAJOR_ELECTIVE:  majorElective++; majorCredit += c.getCredit(); break;
                 case FACULTY_REQUIRED: facultyRequired++; majorCredit += c.getCredit(); break;
                 case FACULTY_ELECTIVE: facultyElective++; majorCredit += c.getCredit(); break;
+                case NONE: majorCredit += c.getCredit(); break;
                 case MSC: mscCredit += c.getCredit(); break;
             }
         }
@@ -97,6 +98,7 @@ public class Student {
             case MAJOR_ELECTIVE:  majorElective++; majorCredit += c.getCredit(); break;
             case FACULTY_REQUIRED: facultyRequired++; majorCredit += c.getCredit(); break;
             case FACULTY_ELECTIVE: facultyElective++; majorCredit += c.getCredit(); break;
+            case NONE: majorCredit += c.getCredit(); break;
             case MSC: mscCredit += c.getCredit(); break;
         }
     }


### PR DESCRIPTION
## 요약
Student.java에서 전공학점 계산 버그 해결 
'컴터'과목이 전공과목에 더해지게 수정

## 변경 유형

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)
