### PR TITLE
[feat/UI] 삭제버튼, 뒤로가기, 졸업 결과 확인 업데이트, 교양과 복수전공을 입력받을 수 있는 필드를  제작했습니다.

### DIFF
--- a/ui/src/ui/GeneralAndDoublePage/GeneralAndDoublePage.java
+++ b/ui/src/ui/GeneralAndDoublePage/GeneralAndDoublePage.java
@@ -133,7 +133,7 @@ public class GeneralAndDoublePage extends JPanel {
         JPanel rightButtonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
         rightButtonPanel.setOpaque(false);
 
-        JButton backButton = new JButton("← 학번 다시 선택");
+        JButton backButton = new JButton("뒤로");
         JButton nextButton = new JButton("다음");
 
         styleSecondaryButton(backButton);
@@ -172,14 +172,14 @@ public class GeneralAndDoublePage extends JPanel {
     }
 
     private void styleSecondaryButton(JButton button) {
-        button.setFont(new Font("나눔고딕", Font.PLAIN, 13));
-        button.setForeground(new Color(0x374151));
-        button.setBackground(new Color(0xF9FAFB));
+        button.setFont(new Font("나눔고딕", Font.BOLD, 14));
+        button.setForeground(new Color(0x111827));
+        button.setBackground(new Color(0xE5E7EB));
+        button.setFocusPainted(false);
         button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
         button.setOpaque(true);
         button.setContentAreaFilled(true);
-        button.setFocusPainted(false);
-        button.setPreferredSize(new Dimension(150, 32));
+        button.setPreferredSize(new Dimension(80, 40));
         button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 

--- a/ui/src/ui/GeneralAndDoublePage/GeneralAndDoublePage.java
+++ b/ui/src/ui/GeneralAndDoublePage/GeneralAndDoublePage.java
@@ -1,0 +1,240 @@
+package ui.GeneralAndDoublePage;
+
+import ui.MainApp;
+import ui.PageNavigator;
+import ui.Pages;
+
+import javax.swing.*;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.DocumentFilter;
+import java.awt.*;
+
+
+public class GeneralAndDoublePage extends JPanel {
+
+    private final JTextField generalCreditsField;
+
+    private final PageNavigator navigator;
+
+    private JToggleButton singleMajorButton;
+    private JToggleButton doubleMajorButton;
+    private boolean isDoubleMajor = false;
+
+    public GeneralAndDoublePage(PageNavigator navigator) {
+        this.navigator = navigator;
+        setLayout(new BorderLayout());
+        setBackground(Color.WHITE);
+
+        JPanel cardPanel = new JPanel(new BorderLayout(0, 20)); // 내부 카드
+        cardPanel.setBackground(Color.WHITE); // 카드 배경 색
+        cardPanel.setBorder(new CompoundBorder( // 카드 테두리
+                new EmptyBorder(30, 40, 30, 40),
+                new LineBorder(new Color(0xE2E4E8), 0, true)   
+        ));
+        add(cardPanel, BorderLayout.CENTER);
+        
+        // 제목 영역
+        JPanel titlePanel = new JPanel();
+        titlePanel.setLayout(new BoxLayout(titlePanel, BoxLayout.Y_AXIS)); // 수직 정렬
+        titlePanel.setOpaque(false);
+
+        JLabel title = new JLabel("교양과 복수전공 유무를 입력해주세요."); // 제목
+        title.setFont(new Font("나눔고딕", Font.BOLD, 22));
+        title.setForeground(new Color(0x111827));
+
+        JLabel subtitle = new JLabel("이수한 교양 학점과 복수전공 유무를 선택해주세요."); // 안내 문구
+        subtitle.setFont(new Font("나눔고딕", Font.PLAIN, 13));
+        subtitle.setForeground(new Color(0x6B7280));
+
+        titlePanel.add(title); // 제목 생성
+        titlePanel.add(Box.createVerticalStrut(8)); // 간격
+        titlePanel.add(subtitle); // 부제목 생성
+
+        cardPanel.add(titlePanel, BorderLayout.NORTH);
+
+        generalCreditsField = new JTextField();
+        generalCreditsField.setPreferredSize(new Dimension(200, 36));
+        generalCreditsField.setMaximumSize(new Dimension(200, 36));
+        generalCreditsField.setFont(new Font("나눔고딕", Font.PLAIN, 16));
+        generalCreditsField.setHorizontalAlignment(JTextField.CENTER);
+
+        JPanel generalPanel = new JPanel();
+        generalPanel.setLayout(new BoxLayout(generalPanel, BoxLayout.Y_AXIS));
+        generalPanel.setOpaque(false);
+
+        JLabel generalLabel = new JLabel("교양 학점");
+        generalLabel.setFont(new Font("나눔고딕", Font.BOLD, 14));
+        generalLabel.setForeground(new Color(0x111827));
+
+        generalLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        generalCreditsField.setAlignmentX(Component.CENTER_ALIGNMENT);
+        generalCreditsField.setMaximumSize(new Dimension(200, 36));
+
+        generalPanel.add(Box.createVerticalStrut(100));
+
+        generalPanel.add(generalLabel);
+        generalPanel.add(Box.createVerticalStrut(8));
+        generalPanel.add(generalCreditsField);
+
+        // 전공 유형 섹션
+        generalPanel.add(Box.createVerticalStrut(32));
+
+        JLabel majorLabel = new JLabel("전공 유형");
+        majorLabel.setFont(new Font("나눔고딕", Font.BOLD, 14));
+        majorLabel.setForeground(new Color(0x111827));
+        majorLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        JPanel majorButtonRow = new JPanel(new FlowLayout(FlowLayout.CENTER, 8, 0));
+        majorButtonRow.setOpaque(false);
+
+        singleMajorButton = new JToggleButton("단일 전공");
+        doubleMajorButton = new JToggleButton("복수 전공");
+
+        styleToggleButton(singleMajorButton);
+        styleToggleButton(doubleMajorButton);
+
+        // 기본값: 단일 전공 선택
+        singleMajorButton.setSelected(true);
+        applyToggleStyle();
+
+        singleMajorButton.addActionListener(e -> {
+            isDoubleMajor = false;
+            singleMajorButton.setSelected(true);
+            doubleMajorButton.setSelected(false);
+            applyToggleStyle();
+        });
+
+        doubleMajorButton.addActionListener(e -> {
+            isDoubleMajor = true;
+            singleMajorButton.setSelected(false);
+            doubleMajorButton.setSelected(true);
+            applyToggleStyle();
+        });
+
+        majorButtonRow.add(singleMajorButton);
+        majorButtonRow.add(doubleMajorButton);
+
+        generalPanel.add(majorLabel);
+        generalPanel.add(Box.createVerticalStrut(8));
+        generalPanel.add(majorButtonRow);
+
+        cardPanel.add(generalPanel, BorderLayout.CENTER);
+
+        // 하단 네비게이션 버튼 영역
+        JPanel bottomPanel = new JPanel(new BorderLayout());
+        bottomPanel.setOpaque(false);
+
+        JPanel leftButtonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        leftButtonPanel.setOpaque(false);
+
+        JPanel rightButtonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
+        rightButtonPanel.setOpaque(false);
+
+        JButton backButton = new JButton("← 학번 다시 선택");
+        JButton nextButton = new JButton("다음");
+
+        styleSecondaryButton(backButton);
+        stylePrimaryButton(nextButton);
+
+        backButton.addActionListener(e -> navigator.navigateTo(Pages.CHOOSE_STUDENT_NUMBER_PAGE));
+        nextButton.addActionListener(e -> {
+            int generalCredits = getGeneralCredits();
+            boolean doubleMajor = isDoubleMajor();
+
+            MainApp app = MainApp.getInstance();
+            app.getGraduationResultPage().updateGeneralInfo(generalCredits, doubleMajor);
+
+            navigator.navigateTo(Pages.SELECT_COURSE_PAGE);
+        });
+
+        leftButtonPanel.add(backButton);
+        rightButtonPanel.add(nextButton);
+
+        bottomPanel.add(leftButtonPanel, BorderLayout.WEST);
+        bottomPanel.add(rightButtonPanel, BorderLayout.EAST);
+
+        cardPanel.add(bottomPanel, BorderLayout.SOUTH);
+    }
+
+    private void stylePrimaryButton(JButton button) {
+        button.setFont(new Font("나눔고딕", Font.BOLD, 14));
+        button.setBackground(new Color(0xE0F2FE));
+        button.setForeground(new Color(0x0F172A));
+        button.setBorder(new LineBorder(new Color(0x7DD3FC), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
+        button.setFocusPainted(false);
+        button.setPreferredSize(new Dimension(140, 36));
+        button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    private void styleSecondaryButton(JButton button) {
+        button.setFont(new Font("나눔고딕", Font.PLAIN, 13));
+        button.setForeground(new Color(0x374151));
+        button.setBackground(new Color(0xF9FAFB));
+        button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
+        button.setFocusPainted(false);
+        button.setPreferredSize(new Dimension(150, 32));
+        button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    private void styleToggleButton(JToggleButton button) {
+        button.setFont(new Font("나눔고딕", Font.PLAIN, 13));
+        button.setForeground(new Color(0x374151));
+        button.setBackground(new Color(0xF9FAFB));
+        button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
+        button.setFocusPainted(false);
+        button.setPreferredSize(new Dimension(110, 32));
+        button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    private void applyToggleStyle() {
+        if (singleMajorButton == null || doubleMajorButton == null) return;
+
+        if (singleMajorButton.isSelected()) {
+            singleMajorButton.setBackground(new Color(0xE0F2FE));
+            singleMajorButton.setForeground(new Color(0x0F172A));
+            singleMajorButton.setBorder(new LineBorder(new Color(0x7DD3FC), 1, true));
+        } else {
+            singleMajorButton.setBackground(new Color(0xF9FAFB));
+            singleMajorButton.setForeground(new Color(0x374151));
+            singleMajorButton.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
+        }
+
+        if (doubleMajorButton.isSelected()) {
+            doubleMajorButton.setBackground(new Color(0xE0F2FE));
+            doubleMajorButton.setForeground(new Color(0x0F172A));
+            doubleMajorButton.setBorder(new LineBorder(new Color(0x7DD3FC), 1, true));
+        } else {
+            doubleMajorButton.setBackground(new Color(0xF9FAFB));
+            doubleMajorButton.setForeground(new Color(0x374151));
+            doubleMajorButton.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
+        }
+    }
+    
+    // 교양 학점 반환
+    public int getGeneralCredits() {
+        String text = generalCreditsField.getText();
+        if (text == null) return 0;
+        text = text.trim();
+        if (text.isEmpty()) return 0;
+        try {
+            return Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    // 복수 전공 여부 반환
+    public boolean isDoubleMajor() {
+        return isDoubleMajor;
+    }
+
+}

--- a/ui/src/ui/GraduationResultPage/GraduationResultPage.java
+++ b/ui/src/ui/GraduationResultPage/GraduationResultPage.java
@@ -47,8 +47,8 @@ public class GraduationResultPage extends JPanel {
         // 제목
         JLabel title = new JLabel("졸업 요건 진단 결과");
         title.setFont(new Font("나눔고딕", Font.BOLD, 28));
-        title.setHorizontalAlignment(SwingConstants.CENTER);
-        title.setBorder(BorderFactory.createEmptyBorder(25, 0, 20, 0));
+        title.setHorizontalAlignment(SwingConstants.LEFT);
+        title.setBorder(BorderFactory.createEmptyBorder(25, 40, 20, 0));
 
         header.add(title, BorderLayout.CENTER);
         add(header, BorderLayout.NORTH);
@@ -100,10 +100,7 @@ public class GraduationResultPage extends JPanel {
         });
     }
 
-    /**
-     * GeneralAndDoublePage에서 입력한 교양 학점 / 전공 유형 정보를 나중에 주입할 때 사용한다.
-     * 값이 주입되기 전에는 기본값 0 / false로 동작한다.
-     */
+    
     public void updateGeneralInfo(int generalCredits, boolean isDoubleMajor) {
         this.generalCredits = generalCredits;
         this.isDoubleMajor = isDoubleMajor;

--- a/ui/src/ui/GraduationResultPage/GraduationResultPage.java
+++ b/ui/src/ui/GraduationResultPage/GraduationResultPage.java
@@ -9,13 +9,17 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.List;
 
+
 public class GraduationResultPage extends JPanel {
 
     // 페이지 전환용
     private final PageNavigator navigator;
     private final String fullId;   // 결과를 계산할 학생 전체 학번
 
-    
+    // GeneralAndDoublePage에서 입력받은 값 (초기값은 0 / false 로 시작하고, 나중에 setter로 갱신)
+    private int generalCredits = 0;      // 이수한 교양 학점
+    private boolean isDoubleMajor = false;   // 복수전공 여부 (false = 단일전공)
+
     private final JLabel statusLabel = new JLabel();
     private final JLabel guideLabel = new JLabel();
 
@@ -96,6 +100,15 @@ public class GraduationResultPage extends JPanel {
         });
     }
 
+    /**
+     * GeneralAndDoublePage에서 입력한 교양 학점 / 전공 유형 정보를 나중에 주입할 때 사용한다.
+     * 값이 주입되기 전에는 기본값 0 / false로 동작한다.
+     */
+    public void updateGeneralInfo(int generalCredits, boolean isDoubleMajor) {
+        this.generalCredits = generalCredits;
+        this.isDoubleMajor = isDoubleMajor;
+    }
+
     // 결과 새로고침
     private void refreshResult() {
         List<String> messages = computeResult(this.fullId);
@@ -114,7 +127,7 @@ public class GraduationResultPage extends JPanel {
 
         List<Integer> courseIds = scc.loadStudentFile(fullId);
 
-        student.inputStudent(fullId, "컴공", false, 50, scc.getDepMgr());
+        student.inputStudent(fullId, "컴공", isDoubleMajor, generalCredits, scc.getDepMgr());
 
         
         if (courseIds != null && !courseIds.isEmpty()) {

--- a/ui/src/ui/GraduationResultPage/GraduationResultPage.java
+++ b/ui/src/ui/GraduationResultPage/GraduationResultPage.java
@@ -143,7 +143,8 @@ public class GraduationResultPage extends JPanel {
         }
 
         String last = messages.get(messages.size() - 1); 
-        boolean pass = last.contains("졸업 가능합니다"); 
+        boolean pass = last.contains("졸업 가능합니다");
+        boolean hideFinalFail = true; // 졸업 실패 문장 숨김
 
         
         resultListPanel.removeAll();
@@ -167,7 +168,30 @@ public class GraduationResultPage extends JPanel {
 
             
             for (String msg : messages) {
-                JPanel row = createResultRow("•", msg, "");
+                // 학부 기초에 대한 문장에서 /0이면 메세지를 출력하지 않음
+                if (msg.contains("학부기초필수") || msg.contains("학부기초선택")) {
+                    
+                    if (msg.contains("/0과목")) {
+                        continue;
+                    }
+                }
+
+                // 마지막 성공 문장을 숨김
+                if (hideFinalFail && msg.contains("졸업 가능합니다! 축하합니다!")) {
+                    continue;
+                }
+
+                String title = msg;
+                String detail = "";
+                
+                int idx2 = msg.indexOf("충족");
+                
+                if (idx2 != -1) {
+                    title = msg.substring(0, idx2 + 2).trim();
+                    detail = msg.substring(idx2 + 2).trim();
+                }
+
+                JPanel row = createResultRow("•", title, detail);
                 resultListPanel.add(row, rowGbc);
                 rowGbc.gridy++;
             }
@@ -177,14 +201,24 @@ public class GraduationResultPage extends JPanel {
             guideLabel.setText("아래 부족한 항목을 채우면 졸업 요건을 만족할 수 있어요.");
 
             for (String msg : messages) {
-                // 부족 항목만 카드로 보여줌
-                if (!msg.contains("부족")) {
+                // 학부 기초에 대한 문장에서 /0이면 메세지를 출력하지 않음
+                if (msg.contains("학부기초필수") || msg.contains("학부기초선택")) {
+                    
+                    if (msg.contains("/0과목")) {
+                        continue;
+                    }
+                }
+
+                // 마지막 실패 문장은 숨김
+                if (hideFinalFail && msg.contains("졸업요건을 만족하지 못했습니다")) {
                     continue;
                 }
+                
 
                 String title = msg;
                 String detail = "";
                 int idx = msg.indexOf("부족");
+                
                 if (idx != -1) {
                     title = msg.substring(0, idx + 2).trim(); 
                     detail = msg.substring(idx + 2).trim();   

--- a/ui/src/ui/MainApp.java
+++ b/ui/src/ui/MainApp.java
@@ -18,12 +18,14 @@ import ui.SelectCoursePage.SelectCoursePage;
 import ui.SelectMscCoursePage.SelectMscCoursePage;
 import ui.ChooseStudentNumberPage.ChooseStudentNumberPage;
 import ui.GraduationResultPage.GraduationResultPage;
+import ui.GeneralAndDoublePage.GeneralAndDoublePage;
 
 public class MainApp {
 
     private JFrame frame;          // 메인 윈도우
     private JPanel rootPanel;      // 여러 페이지를 담는 루트 패널
     private CardLayout cardLayout; // 페이지 전환용 레이아웃
+    private static MainApp instance;
 
     // 백엔드
     private final StudentCourseCount scc;          // 과/졸업요건/학생파일 관리
@@ -32,8 +34,10 @@ public class MainApp {
     // 현재 로그인한(?) 학생 정보
     private String fullId = "";                    // 전체 학번 (예: 202015071)
     private String departmentName = "컴공";        // 학과 이름
-    private boolean isDoubleMajor = false;         // 복수전공 여부
-    private int generalCredit = 50;                // 교양 학점 (임시 기본값)
+
+    // 교양 학점 / 전공 유형 정보 (GeneralAndDoublePage에서 입력받을 값)
+    private int generalCredit = 0;                 // 이수한 교양 학점
+    private boolean isDoubleMajor = false;         // 복수전공 여부 (false = 단일전공)
 
     private Student currentStudent;
 
@@ -41,67 +45,56 @@ public class MainApp {
     private SelectCoursePage selectCoursePage;
     private SelectMscCoursePage selectMscCoursePage;
     private GraduationResultPage graduationResultPage;
+    private GeneralAndDoublePage generalAndDoublePage;
 
     public MainApp() {
+        instance = this;
 
-        
         scc = new StudentCourseCount();
         scc.run();                        
-        courseMgr = scc.getCourseMgr();   
+        courseMgr = scc.getCourseMgr();
 
-        
         frame = new JFrame("졸업 요건 확인 프로그램");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(900, 650);
         frame.setLocationRelativeTo(null); 
 
-        
         cardLayout = new CardLayout();
         rootPanel = new JPanel(cardLayout);
 
-        
         PageNavigator navigator = pageKey -> {
             cardLayout.show(rootPanel, pageKey);
             rootPanel.revalidate();
             rootPanel.repaint();
         };
 
-        
         Consumer<String> onFullIdSelected = (inputFullId) -> {
             System.out.println("입력한 학번: " + inputFullId);
             this.fullId = inputFullId;
-            this.currentStudent = new Student();
 
-        
+            // 학번에 해당하는 기존 수강 과목 ID들을 파일에서 불러온다.
             List<Integer> savedIds = scc.loadStudentFile(fullId);
             System.out.println("불러온 과목 개수: " + savedIds.size());
 
-        
-            currentStudent.inputStudent(
+            // 전공 커리큘럼 목록은 학과/학번 정보만 있으면 얻을 수 있으므로,
+            // 임시 Student를 만들어 GraduationRule에서 과목 리스트만 가져온다.
+            Student tempStudent = new Student();
+            tempStudent.inputStudent(
                     fullId,
                     departmentName,
-                    isDoubleMajor,
-                    generalCredit,
+                    false,          // 전공 유형 / 교양 학점은 커리큘럼 목록에는 영향이 없다고 가정
+                    0,
                     scc.getDepMgr()
             );
 
-            
-            if (!savedIds.isEmpty()) {
-                currentStudent.loadStudentCourses(savedIds, courseMgr);
-            } else {
-            
-                System.out.println("신규 학번, 파일 생성");
-                scc.saveStudentFile(currentStudent);
-            }
-
-            
             List<Course> curriculumCourses =
-                    currentStudent.getGraduationRule().getCourses();
+                    tempStudent.getGraduationRule().getCourses();
 
+            // MSC 과목 목록은 전체 과목 Manager에서 타입으로 필터링
             List<Course> mscCourses =
                     courseMgr.filterBy(c -> c.getType() == CourseType.MSC);
 
-            
+            // 기존 페이지가 있다면 제거
             if (selectCoursePage != null) {
                 rootPanel.remove(selectCoursePage);
             }
@@ -112,47 +105,45 @@ public class MainApp {
                 rootPanel.remove(graduationResultPage);
             }
 
-            
+            // 전공/MSC 선택 페이지 및 결과 페이지를 새로 생성
             selectCoursePage = new SelectCoursePage(
                     navigator,
-                    curriculumCourses,   // 전공 과목 목록
+                    curriculumCourses,
                     fullId,
-                    savedIds            // 이미 들은 과목 id 리스트 
-                   
+                    savedIds
             );
 
             selectMscCoursePage = new SelectMscCoursePage(
                     navigator,
                     fullId,
                     mscCourses,
-                    savedIds            
+                    savedIds
             );
 
             graduationResultPage = new GraduationResultPage(
                     navigator,
-                    fullId             
+                    fullId                    
             );
 
-            
             rootPanel.add(selectCoursePage, Pages.SELECT_COURSE_PAGE);
             rootPanel.add(selectMscCoursePage, Pages.SELECT_MSC_PAGE);
             rootPanel.add(graduationResultPage, Pages.GRADUATION_RESULT_PAGE);
 
-            
-            navigator.navigateTo(Pages.SELECT_COURSE_PAGE);
+            // 학번 선택 후에는 교양/전공 유형 입력 페이지로 이동
+            navigator.navigateTo(Pages.GENERAL_AND_DOUBLE_PAGE);
         };
 
-        
         MainPage mainPage = new MainPage(navigator);
         ChooseStudentNumberPage choosePage = new ChooseStudentNumberPage(
                 navigator,
                 onFullIdSelected       
         );
+        generalAndDoublePage = new GeneralAndDoublePage(navigator);
 
         rootPanel.add(mainPage, Pages.MAIN_PAGE);
         rootPanel.add(choosePage, Pages.CHOOSE_STUDENT_NUMBER_PAGE);
+        rootPanel.add(generalAndDoublePage, Pages.GENERAL_AND_DOUBLE_PAGE);
 
-        
         cardLayout.show(rootPanel, Pages.MAIN_PAGE);
 
         frame.setContentPane(rootPanel);
@@ -178,6 +169,14 @@ public class MainApp {
 
     public Manager<Course> getCourseMgr() {
         return courseMgr;
+    }
+
+    public GraduationResultPage getGraduationResultPage() {
+        return graduationResultPage;
+    }
+
+    public static MainApp getInstance() {
+        return instance;
     }
 
     public static void main(String[] args) {

--- a/ui/src/ui/MainApp.java
+++ b/ui/src/ui/MainApp.java
@@ -14,10 +14,10 @@ import graduate.Manager;
 import graduate.Student;
 import graduate.StudentCourseCount;
 import ui.MainPage.MainPage;
-import ui.chooseStudentNumberPage.ChooseStudentNumberPage;
-import ui.selectCoursePage.SelectCoursePage;
+import ui.SelectCoursePage.SelectCoursePage;
+import ui.SelectMscCoursePage.SelectMscCoursePage;
+import ui.ChooseStudentNumberPage.ChooseStudentNumberPage;
 import ui.GraduationResultPage.GraduationResultPage;
-import ui.selectMscCoursePage.SelectMscCoursePage;
 
 public class MainApp {
 

--- a/ui/src/ui/Pages.java
+++ b/ui/src/ui/Pages.java
@@ -7,4 +7,5 @@ public final class Pages {
     public static final String SELECT_COURSE_PAGE = "SelectCoursePage";
     public static final String GRADUATION_RESULT_PAGE = "GraduationResultPage";
     public static final String SELECT_MSC_PAGE = "SelectMscCoursePage";
+    public static final String GENERAL_AND_DOUBLE_PAGE = "GeneralAndDoublePage";
 }

--- a/ui/src/ui/chooseStudentNumberPage/ChooseStudentNumberPage.java
+++ b/ui/src/ui/chooseStudentNumberPage/ChooseStudentNumberPage.java
@@ -1,4 +1,4 @@
-package ui.chooseStudentNumberPage;
+package ui.ChooseStudentNumberPage;
 
 import javax.swing.*;
 import javax.swing.text.*;

--- a/ui/src/ui/chooseStudentNumberPage/ChooseStudentNumberPage.java
+++ b/ui/src/ui/chooseStudentNumberPage/ChooseStudentNumberPage.java
@@ -66,7 +66,7 @@ public class ChooseStudentNumberPage extends JPanel {
         onYearSelected.accept(fullId);
 
         // 다음 페이지 이동
-        navigator.navigateTo(Pages.SELECT_COURSE_PAGE);
+        navigator.navigateTo(Pages.GENERAL_AND_DOUBLE_PAGE);
     }
 
     // 숫자만 입력 받도록

--- a/ui/src/ui/selectCoursePage/SelectCoursePage.java
+++ b/ui/src/ui/selectCoursePage/SelectCoursePage.java
@@ -406,8 +406,8 @@ public class SelectCoursePage extends JPanel {
             student.deleteCourse(courseId, scc.getCourseMgr());
 
             
-            selectedCourseIndexes.remove(Integer.valueOf(courseId));
-            selectedCourses.removeIf(c -> c.getId() == courseId);
+            selectedCourseIndexes.remove(Integer.valueOf(courseId)); // 선택된 과목 ID 목록에서 제거
+            selectedCourses.removeIf(c -> c.getId() == courseId); // 선택한 과목 목록에서 제거
 
             deletedCount++;
             System.out.println("삭제한 과목 코드: " + courseId);

--- a/ui/src/ui/selectCoursePage/SelectCoursePage.java
+++ b/ui/src/ui/selectCoursePage/SelectCoursePage.java
@@ -240,7 +240,7 @@ public class SelectCoursePage extends JPanel {
         JButton resultButton = new JButton("MSC 과목 담으러 가기");
 
         styleBackButton(backButton);
-        styleSecondaryButton(deleteButton);
+        stylePrimaryButton(deleteButton);
         stylePrimaryButton(addButton);
         styleSecondaryButton(showButton);
         stylePrimaryButton(resultButton);
@@ -250,7 +250,7 @@ public class SelectCoursePage extends JPanel {
         backButton.addActionListener(e -> {
             navigator.navigateTo(Pages.CHOOSE_STUDENT_NUMBER_PAGE);
         });
-        // deleteButton.addActionListener(e -> student.deleteCourse(, scc.getCourseMgr()));
+        deleteButton.addActionListener(e -> deleteSelectedCourses());
         addButton.addActionListener(e -> addSelectedCourses());
         showButton.addActionListener(e -> printAccumulatedCourses());
         resultButton.addActionListener(e -> {
@@ -371,6 +371,60 @@ public class SelectCoursePage extends JPanel {
         courseTable.repaint(); // 테이블을 다시 그림
     }
 
+    private void deleteSelectedCourses() {
+        int[] selectedRows = courseTable.getSelectedRows(); // 선택된 행 인덱스 배열
+
+        if (selectedRows.length == 0) {
+            System.out.println("삭제할 과목이 선택되지 않았습니다.");
+            return;
+        }
+
+        int deletedCount = 0;
+
+        for (int rowIndex : selectedRows) {
+            
+            Object value = tableModel.getValueAt(rowIndex, 0); // ID 값 가져오기
+            if (value == null) { // value가 없으면 넘어감
+                continue;
+            }
+
+            int courseId; // 과목 ID를 정의
+            try {
+                courseId = Integer.parseInt(value.toString()); // ID를 파싱을 해서 courseId에 삽입
+            } catch (NumberFormatException e) { // 오류가 발생하면
+                System.out.println("ID 파싱 오류(삭제): " + value); // 오류 출력하고
+                continue; // 넘어감
+            }
+
+            // 실제로 담긴 과목이 아니면 스킵
+            if (!selectedCourseIndexes.contains(courseId)) {
+                continue;
+            }
+
+            
+            // 학생 객체에서 과목 삭제
+            student.deleteCourse(courseId, scc.getCourseMgr());
+
+            
+            selectedCourseIndexes.remove(Integer.valueOf(courseId));
+            selectedCourses.removeIf(c -> c.getId() == courseId);
+
+            deletedCount++;
+            System.out.println("삭제한 과목 코드: " + courseId);
+        }
+
+        if (deletedCount == 0) {
+            System.out.println("실제로 삭제된 과목이 없습니다.");
+            return;
+        }
+
+        // 변경된 내역을 txt에 덮어쓰기
+        scc.saveStudentFile(student);
+
+        System.out.println("삭제된 과목: " + deletedCount + "개");
+        courseTable.repaint(); // 테이블을 다시 그림
+    }
+
     
     private void printAccumulatedCourses() {
         if (selectedCourses.isEmpty()) { // 담긴 과목이 없으면
@@ -379,10 +433,6 @@ public class SelectCoursePage extends JPanel {
         }
 
         System.out.println("=== 지금까지 담은 과목 목록 ===");
-        // for (Course c : selectedCourses) {
-            
-        //     System.out.println(c.toString()); // 과목 정보들을 출력
-        // }
 
         List<String> takenCourseList = student.getTakenMajorCourseList();
         for (String s : takenCourseList) {

--- a/ui/src/ui/selectCoursePage/SelectCoursePage.java
+++ b/ui/src/ui/selectCoursePage/SelectCoursePage.java
@@ -234,11 +234,13 @@ public class SelectCoursePage extends JPanel {
 
         // 버튼 생성
         JButton backButton = new JButton("뒤로");
+        JButton deleteButton = new JButton("선택 과목 삭제");
         JButton addButton = new JButton("선택 과목 담기");
         JButton showButton = new JButton("지금까지 담은 전공 과목 보기");
         JButton resultButton = new JButton("MSC 과목 담으러 가기");
 
         styleBackButton(backButton);
+        styleSecondaryButton(deleteButton);
         stylePrimaryButton(addButton);
         styleSecondaryButton(showButton);
         stylePrimaryButton(resultButton);
@@ -248,6 +250,7 @@ public class SelectCoursePage extends JPanel {
         backButton.addActionListener(e -> {
             navigator.navigateTo(Pages.CHOOSE_STUDENT_NUMBER_PAGE);
         });
+        // deleteButton.addActionListener(e -> student.deleteCourse(, scc.getCourseMgr()));
         addButton.addActionListener(e -> addSelectedCourses());
         showButton.addActionListener(e -> printAccumulatedCourses());
         resultButton.addActionListener(e -> {
@@ -257,6 +260,7 @@ public class SelectCoursePage extends JPanel {
         // 패널에 추가
         leftPanel.add(backButton);
 
+        rightPanel.add(deleteButton);
         rightPanel.add(addButton);
         rightPanel.add(showButton);
         rightPanel.add(resultButton);

--- a/ui/src/ui/selectCoursePage/SelectCoursePage.java
+++ b/ui/src/ui/selectCoursePage/SelectCoursePage.java
@@ -220,52 +220,87 @@ public class SelectCoursePage extends JPanel {
         scrollPane.setBorder(new EmptyBorder(10, 0, 10, 0));  // 스크롤 패널 테두리
         centerPanel.add(scrollPane, BorderLayout.CENTER); // 패널에 스크롤 패널 추가
 
-        // 하단 버튼 선택
-        JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 0));
-        bottomPanel.setOpaque(false);
+        // === 하단 버튼 영역 (좌/우 분리) ===
+        JPanel bottomWrapper = new JPanel(new BorderLayout());
+        bottomWrapper.setOpaque(false);
 
-        JButton addButton = new JButton("선택 과목 담기"); // 선택한 과목을 담는 버튼
-        JButton showButton = new JButton("지금까지 담은 전공 과목 보기"); // 지금까지 담은 과목을 console로 확인하는 버튼
-        JButton resultButton = new JButton("MSC 과목 담기"); // 졸업의 결과를 확인할 수 있는 페이지로 이동하는 버튼
+        // 왼쪽 (뒤로가기)
+        JPanel leftPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
+        leftPanel.setOpaque(false);
 
-        stylePrimaryButton(addButton); // 주요 버튼 스타일
-        styleSecondaryButton(showButton); // 보조 버튼 스타일
-        stylePrimaryButton(resultButton); // 주요 버튼 스타일
+        // 오른쪽 (기존 버튼들)
+        JPanel rightPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 0));
+        rightPanel.setOpaque(false);
 
-        // 버튼 클릭 시 동작 연결
-        addButton.addActionListener(e -> addSelectedCourses()); // 선택한 과목을 누적
-        showButton.addActionListener(e -> printAccumulatedCourses()); // 지금까지 담은 과목 출력
+        // 버튼 생성
+        JButton backButton = new JButton("뒤로");
+        JButton addButton = new JButton("선택 과목 담기");
+        JButton showButton = new JButton("지금까지 담은 전공 과목 보기");
+        JButton resultButton = new JButton("MSC 과목 담으러 가기");
+
+        styleBackButton(backButton);
+        stylePrimaryButton(addButton);
+        styleSecondaryButton(showButton);
+        stylePrimaryButton(resultButton);
+        
+
+        // 이벤트
+        backButton.addActionListener(e -> {
+            navigator.navigateTo(Pages.CHOOSE_STUDENT_NUMBER_PAGE);
+        });
+        addButton.addActionListener(e -> addSelectedCourses());
+        showButton.addActionListener(e -> printAccumulatedCourses());
         resultButton.addActionListener(e -> {
-            navigator.navigateTo(Pages.SELECT_MSC_PAGE); // MSC 페이지로 이동
+            navigator.navigateTo(Pages.SELECT_MSC_PAGE);
         });
 
-        bottomPanel.add(addButton);
-        bottomPanel.add(showButton);
-        bottomPanel.add(resultButton);
+        // 패널에 추가
+        leftPanel.add(backButton);
 
-        cardPanel.add(bottomPanel, BorderLayout.SOUTH);
+        rightPanel.add(addButton);
+        rightPanel.add(showButton);
+        rightPanel.add(resultButton);
+
+        bottomWrapper.add(leftPanel, BorderLayout.WEST);
+        bottomWrapper.add(rightPanel, BorderLayout.EAST);
+
+        cardPanel.add(bottomWrapper, BorderLayout.SOUTH);
     }
 
     
     // 버튼 스타일링
-    private void stylePrimaryButton(JButton button) {
+    public void stylePrimaryButton(JButton button) {
         button.setFont(new Font("나눔고딕", Font.BOLD, 14));
-        button.setForeground(new Color(0x111827));
-        button.setBackground(new Color(0x2563EB));
+        button.setBackground(new Color(0xE0F2FE));
+        button.setForeground(new Color(0x0F172A));
+        button.setBorder(new LineBorder(new Color(0x7DD3FC), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
         button.setFocusPainted(false);
-        button.setBorder(new LineBorder(new Color(0x1D4ED8), 1, true));
         button.setPreferredSize(new Dimension(150, 40));
         button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 
     // 버튼 스타일링
-    private void styleSecondaryButton(JButton button) {
+    public void styleSecondaryButton(JButton button) {
         button.setFont(new Font("나눔고딕", Font.BOLD, 14));
         button.setForeground(new Color(0x111827));
         button.setBackground(new Color(0xE5E7EB));
         button.setFocusPainted(false);
         button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
         button.setPreferredSize(new Dimension(190, 40));
+        button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    public static void styleBackButton(JButton button) {
+        button.setFont(new Font("나눔고딕", Font.BOLD, 14));
+        button.setForeground(new Color(0x111827));
+        button.setBackground(new Color(0xE5E7EB));
+        button.setFocusPainted(false);
+        button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
+        button.setPreferredSize(new Dimension(80, 40));
         button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
     

--- a/ui/src/ui/selectCoursePage/SelectCoursePage.java
+++ b/ui/src/ui/selectCoursePage/SelectCoursePage.java
@@ -1,4 +1,4 @@
-package ui.selectCoursePage;
+package ui.SelectCoursePage;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;

--- a/ui/src/ui/selectCoursePage/SelectCoursePage.java
+++ b/ui/src/ui/selectCoursePage/SelectCoursePage.java
@@ -22,7 +22,7 @@ import ui.Pages;
 public class SelectCoursePage extends JPanel {
 
     private final PageNavigator navigator;     // 페이지 네비게이터
-    private final String fullId;               // 선택한 학번의 전체 ID (예: 202015071)
+    private final String fullId;               // 선택한 학번의 전체 ID
     private final List<Integer> selectedCourseIndexes = new ArrayList<>(); // 사용자가 선택한 과목 ID 목록    
     private final List<Course> courseList = new ArrayList<>(); // 전체 과목 리스트
     private final List<Course> selectedCourses = new ArrayList<>(); // 선택한 과목 리스트
@@ -248,7 +248,7 @@ public class SelectCoursePage extends JPanel {
 
         // 이벤트
         backButton.addActionListener(e -> {
-            navigator.navigateTo(Pages.CHOOSE_STUDENT_NUMBER_PAGE);
+            navigator.navigateTo(Pages.GENERAL_AND_DOUBLE_PAGE);
         });
         deleteButton.addActionListener(e -> deleteSelectedCourses());
         addButton.addActionListener(e -> addSelectedCourses());

--- a/ui/src/ui/selectMscCoursePage/SelectMscCoursePage.java
+++ b/ui/src/ui/selectMscCoursePage/SelectMscCoursePage.java
@@ -210,17 +210,30 @@ public class SelectMscCoursePage extends JPanel {
         centerPanel.add(scrollPane, BorderLayout.CENTER);
 
         // 버튼 영역
-        JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 0));
-        bottomPanel.setOpaque(false);
 
+        JPanel bottomWrapper = new JPanel(new BorderLayout());
+        bottomWrapper.setOpaque(false);
+
+
+        JPanel leftPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 0));
+        leftPanel.setOpaque(false);
+
+        JPanel rightPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 10, 0));
+        rightPanel.setOpaque(false);
+
+        JButton backButton = new JButton("뒤로");
         JButton addButton = new JButton("MSC 과목 담기");
         JButton showButton = new JButton("지금까지 담은 MSC 과목 보기");
         JButton nextButton = new JButton("졸업 결과 보기");
 
+        styleBackButton(backButton);
         stylePrimaryButton(addButton);
         styleSecondaryButton(showButton);
         stylePrimaryButton(nextButton);
 
+        backButton.addActionListener(e -> {
+            navigator.navigateTo(Pages.SELECT_COURSE_PAGE);
+        });
         addButton.addActionListener(e -> addSelectedMscCourses());
         showButton.addActionListener(e -> printAccumulatedMscCourses());
         
@@ -228,11 +241,16 @@ public class SelectMscCoursePage extends JPanel {
             navigator.navigateTo(Pages.GRADUATION_RESULT_PAGE);
         });
 
-        bottomPanel.add(addButton);
-        bottomPanel.add(showButton);
-        bottomPanel.add(nextButton);
+        leftPanel.add(backButton);
 
-        cardPanel.add(bottomPanel, BorderLayout.SOUTH);
+        rightPanel.add(addButton);
+        rightPanel.add(showButton);
+        rightPanel.add(nextButton);
+
+        bottomWrapper.add(leftPanel, BorderLayout.WEST);
+        bottomWrapper.add(rightPanel, BorderLayout.EAST);
+
+        cardPanel.add(bottomWrapper, BorderLayout.SOUTH);
 
         // 테이블 데이터 채우기
         fillTableWithMscCourses();
@@ -341,10 +359,12 @@ public class SelectMscCoursePage extends JPanel {
     
     private void stylePrimaryButton(JButton button) {
         button.setFont(new Font("나눔고딕", Font.BOLD, 14));
-        button.setForeground(new Color(0x111827));
-        button.setBackground(new Color(0x2563EB));
+        button.setBackground(new Color(0xE0F2FE));
+        button.setForeground(new Color(0x0F172A));
+        button.setBorder(new LineBorder(new Color(0x7DD3FC), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
         button.setFocusPainted(false);
-        button.setBorder(new LineBorder(new Color(0x1D4ED8), 1, true));
         button.setPreferredSize(new Dimension(150, 40));
         button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
@@ -356,6 +376,18 @@ public class SelectMscCoursePage extends JPanel {
         button.setFocusPainted(false);
         button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
         button.setPreferredSize(new Dimension(190, 40));
+        button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+    }
+
+    private static void styleBackButton(JButton button) {
+        button.setFont(new Font("나눔고딕", Font.BOLD, 14));
+        button.setForeground(new Color(0x111827));
+        button.setBackground(new Color(0xE5E7EB));
+        button.setFocusPainted(false);
+        button.setBorder(new LineBorder(new Color(0xD1D5DB), 1, true));
+        button.setOpaque(true);
+        button.setContentAreaFilled(true);
+        button.setPreferredSize(new Dimension(80, 40));
         button.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 }

--- a/ui/src/ui/selectMscCoursePage/SelectMscCoursePage.java
+++ b/ui/src/ui/selectMscCoursePage/SelectMscCoursePage.java
@@ -1,4 +1,4 @@
-package ui.selectMscCoursePage;
+package ui.SelectMscCoursePage;
 
 import graduate.Course;
 import graduate.StudentCourseCount;


### PR DESCRIPTION
## 요약

- 과목 삭제 버튼 생성
- 이전 페이지 이동 버튼 생성
- 졸업 결과 피드백 제공
- 교양, 복수전공 페이지 제작

## 관련 이슈

- #17 

## 변경 유형

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- 사용자가 잘못 입력한 과목에 대해 삭제 버튼을 생성했습니다.
- MSC, SelectCoursePAge 등 다른 페이지에서 뒤로갈 수 있는 뒤로가기 버튼을 생성했습니다.
- 졸업 결과를 확인할 때 자신이 통과한 졸업 요건에 대한 피드백을 받을 수 있도록 업데이트를 진행했습니다.
- 교양, 복수 전공에 대해 입력을 받을 수 있는 페이지를 만들었습니다.
